### PR TITLE
Support full build from on PRs from forks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,13 +58,6 @@ jobs:
       with:
         name: kalium-dist
         path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Build and upload binaries
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   checkdependencies:
     name: Check dependencies for any security advisories
@@ -80,13 +73,6 @@ jobs:
         check-latest: true
     - name: Execute gradle dependencyCheckAnalyze task
       run: ./gradlew dependencyCheckAnalyze -x test
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Check dependencies for any security advisories
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   test:
     name: Unit tests
@@ -102,13 +88,6 @@ jobs:
         check-latest: true
     - name: Execute gradle test
       run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Unit tests
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   itest:
     name: Integration tests
@@ -168,13 +147,6 @@ jobs:
       with:
        name: itest-logs
        path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#    - name: Send slack notification
-#      uses: homoluctus/slatify@v3.0.0
-#      if: always()
-#      with:
-#        type: ${{job.status}}
-#        job_name: Integration tests
-#        url: ${{ secrets.SLACK_WEBHOOK }}
 
   remote_enclave_itest:
     name: Remote enclave integration tests
@@ -234,13 +206,6 @@ jobs:
         with:
           name: remote_enclave_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Remote enclave integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   cucumber_itest:
     name: Cucumber itests
@@ -300,13 +265,6 @@ jobs:
         with:
           name: cucumber_itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Cucumber itests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   vaultTests:
     name: Key vault integration tests
@@ -375,12 +333,6 @@ jobs:
         with:
           name: vault-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Key vault integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   recovery_itest:
     name: Recovery integration tests
@@ -440,13 +392,6 @@ jobs:
         with:
           name: recovery-itest-logs
           path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Recovery integration tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   build_image:
     name: Build develop Docker image
@@ -529,13 +474,6 @@ jobs:
         with:
           name: gauge-reports
           path: /tmp/acctests/gauge
-#      - name: Send slack notification
-#        uses: homoluctus/slatify@v3.0.0
-#        if: always()
-#        with:
-#          type: ${{job.status}}
-#          job_name: Quorum acceptance tests
-#          url: ${{ secrets.SLACK_WEBHOOK }}
 
   push_docker_develop:
     name: Push develop image to DockerHub

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -413,7 +413,7 @@ jobs:
       - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:
-          tags: $TESSERA_DOCKER_IMAGE:develop
+          tags: ${TESSERA_DOCKER_IMAGE}:develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -418,7 +418,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.date.outputs.now }}
-          push: false
+
           file: docker/tessera.Dockerfile
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -458,7 +458,7 @@ jobs:
         run: |
           # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
           # from forks (that don't have access to secrets) pushing to the official repo 
-#          val="${DOCKER_REPO:-quorumtest}"
+          # val="${DOCKER_REPO:-quorumtest}"
           echo "::set-output name=docker-repo::${DOCKER_REPO:-quorumtest}"
       - name: Checkout code from SCM
         uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,8 @@ on:
 env:
   GRADLE_CACHE_KEY: ${{ github.run_id }}-gradle-${{ github.run_number }}-${{ github.run_number }}-${{ github.sha }}
   DIST_TAR: tessera-dist/build/distributions/tessera-*.tar
+  TESSERA_DOCKER_IMAGE: quorumengineering/tessera
+  QUORUM_DOCKER_IMAGE: quorumengineering/quorum
 jobs:
   build:
     name: Build and upload binaries
@@ -451,15 +453,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - name: Use secret or default
-        id: get_docker_repo
-        env:
-          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
-        run: |
-          # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
-          # from forks (that don't have access to secrets) pushing to the official repo 
-          # val="${DOCKER_REPO:-quorumtest}"
-          echo "::set-output name=docker-repo::${DOCKER_REPO:-quorumtest}"
       - name: Checkout code from SCM
         uses: actions/checkout@v2
       - name: Download tessera dist
@@ -472,10 +465,10 @@ jobs:
       - name: Get current date-time (RFC 3339 standard)
         id: date
         run: echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      - name: Build image as portable tar
+      - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.get_docker_repo.outputs.docker-repo }}:develop
+          tags: $TESSERA_DOCKER_IMAGE:develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -485,7 +478,7 @@ jobs:
           # context must be explicitly provided to prevent docker/build-push-action checking out the repo again and deleting the downloaded artifacts
           context: .
           outputs: type=docker,dest=/tmp/tessera-develop-image.tar
-      - name: Upload artifact
+      - name: upload-artifact portable Docker image
         uses: actions/upload-artifact@v2
         with:
           name: tessera-develop-image
@@ -504,7 +497,7 @@ jobs:
           distribution: 'adopt'
           java-version: 14
           check-latest: true
-      - name: Download image artifact
+      - name: download-artifact portable Docker image
         uses: actions/download-artifact@v2
         with:
           name: tessera-develop-image
@@ -518,19 +511,18 @@ jobs:
       - name: Get version of Quorum to use
         id: quorumver
         run: |
-          tagversion=`cat version.txt | cut -d'-' -f1`
-          echo "$tagversion" > version.txt
-          VERSION=${tagversion%.*}
-          RESP_CODE=$(docker manifest inspect quorumengineering/quorum:$VERSION> /dev/null ; echo $?)
+          # trim the tessera version (e.g. 1.2.3-SNAPSHOT --> 1.2)
+          QUORUM_MINOR_VERSION=$(cat version.txt | cut -d '-' -f 1 | cut -d '.' -f 1,2) 
+          RESP_CODE=$(docker manifest inspect $QUORUM_DOCKER_IMAGE:$QUORUM_MINOR_VERSION> /dev/null ; echo $?)
           if [ ! $RESP_CODE -eq 0 ]; then
-            echo "no quorum image found for $VERSION"
+            echo "no quorum image found for $QUORUM_MINOR_VERSION"
             VERSION=latest
           fi
-          echo "using version $VERSION"
-          echo ::set-output name=version::$VERSION
+          echo "using version $QUORUM_MINOR_VERSION"
+          echo ::set-output name=version::$QUORUM_MINOR_VERSION
       - name: Execute acceptance tests
         run:
-          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_quorum_docker_image='{name="quorumengineering/quorum:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
+          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_tessera_docker_image='{name="${TESSERA_DOCKER_IMAGE}:develop",local=true}' -e TF_VAR_quorum_docker_image='{name="${QUORUM_DOCKER_IMAGE}:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
       - name: Upload Gauge report
         uses: actions/upload-artifact@v2
         if: always()
@@ -553,16 +545,7 @@ jobs:
     needs: [build_image, atest]
     runs-on: ubuntu-latest
     steps:
-      - name: Use secret or default
-        id: get_docker_repo
-        env:
-          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
-        run: |
-          # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
-          # from forks (that don't have access to secrets) pushing to the official repo 
-          val="${DOCKER_REPO:-quorumtest}"
-          echo "::set-output name=docker-repo::$val"
-      - name: Download image artifact
+      - name: download-artifact portable Docker image
         uses: actions/download-artifact@v2
         with:
           name: tessera-develop-image
@@ -580,4 +563,4 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Push image
         run : |
-          docker push ${{ steps.get_docker_repo.outputs.docker-repo }}:develop
+          docker push ${TESSERA_DOCKER_IMAGE}:develop

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,324 +74,324 @@ jobs:
     - name: Execute gradle dependencyCheckAnalyze task
       run: ./gradlew dependencyCheckAnalyze -x test
 
-  test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code from SCM
-      uses: actions/checkout@v2
-    - name: Set up Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: 14
-        check-latest: true
-    - name: Execute gradle test
-      run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
-
-  itest:
-    name: Integration tests
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code from SCM
-      uses: actions/checkout@v2
-    - name: Set up Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: 14
-        check-latest: true
-    - name: Download tessera dist
-      uses: actions/download-artifact@v2
-      with:
-        name: tessera-dists
-        path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-    - name: Download tessera enclave dist
-      uses: actions/download-artifact@v2
-      with:
-        name: enclave-dists
-        path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-    - name: Download aws key vault dist
-      uses: actions/download-artifact@v2
-      with:
-        name: aws-key-vault-dist
-        path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-    - name: Download azure key vault dist
-      uses: actions/download-artifact@v2
-      with:
-        name: azure-key-vault-dist
-        path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-    - name: Download hashicorp key vault dist
-      uses: actions/download-artifact@v2
-      with:
-        name: hashicorp-key-vault-dist
-        path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-    - name: Download kalium encryptor dist
-      uses: actions/download-artifact@v2
-      with:
-        name: kalium-dist
-        path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-    - name: Execute gradle integration tests
-      run: |
-        ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --fail-fast -PexcludeTests="RunHashicorpIT,AwsKeyVaultIT,RecoverIT,RunAzureIT,RestSuiteHttpH2RemoteEnclaveEncTypeEC,CucumberTestSuite" --info
-    - name: Upload Junit reports
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-       name: itest-junit-report
-       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-    - name: Upload test logs
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-       name: itest-logs
-       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-
-  remote_enclave_itest:
-    name: Remote enclave integration tests
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code from SCM
-        uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 14
-          check-latest: true
-      - name: Download tessera dist
-        uses: actions/download-artifact@v2
-        with:
-          name: tessera-dists
-          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-      - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
-        with:
-          name: enclave-dists
-          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-      - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: aws-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-      - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: azure-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-      - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: hashicorp-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-      - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
-        with:
-          name: kalium-dist
-          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-      - name: Execute gradle integration tests
-        run: |
-          ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC --info
-      - name: Upload junit reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: remote_enclave_itest-junit-report
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: remote_enclave_itest-logs
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-
-  cucumber_itest:
-    name: Cucumber itests
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code from SCM
-        uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 14
-          check-latest: true
-      - name: Download tessera dist
-        uses: actions/download-artifact@v2
-        with:
-          name: tessera-dists
-          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-      - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
-        with:
-          name: enclave-dists
-          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-      - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: aws-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-      - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: azure-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-      - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: hashicorp-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-      - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
-        with:
-          name: kalium-dist
-          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-      - name: Execute gradle
-        run: |
-          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests CucumberTestSuite --info
-      - name: Upload junit reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cucumber_itest-junit-report
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cucumber_itest-logs
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-
-  vaultTests:
-    name: Key vault integration tests
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code from SCM
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 14
-          check-latest: true
-      - name: Download tessera dist
-        uses: actions/download-artifact@v2
-        with:
-          name: tessera-dists
-          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-      - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
-        with:
-          name: enclave-dists
-          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-      - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: aws-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-      - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: azure-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-      - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: hashicorp-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-      - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
-        with:
-          name: kalium-dist
-          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-      - name: Run AWS tests
-        run: |
-          ./gradlew :tests:acceptance-test:test --tests AwsKeyVaultIT --info
-#      - name: Run azure tests
+#  test:
+#    name: Unit tests
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Checkout code from SCM
+#      uses: actions/checkout@v2
+#    - name: Set up Java
+#      uses: actions/setup-java@v2
+#      with:
+#        distribution: 'adopt'
+#        java-version: 14
+#        check-latest: true
+#    - name: Execute gradle test
+#      run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
+#
+#  itest:
+#    name: Integration tests
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Checkout code from SCM
+#      uses: actions/checkout@v2
+#    - name: Set up Java
+#      uses: actions/setup-java@v2
+#      with:
+#        distribution: 'adopt'
+#        java-version: 14
+#        check-latest: true
+#    - name: Download tessera dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: tessera-dists
+#        path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+#    - name: Download tessera enclave dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: enclave-dists
+#        path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+#    - name: Download aws key vault dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: aws-key-vault-dist
+#        path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+#    - name: Download azure key vault dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: azure-key-vault-dist
+#        path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+#    - name: Download hashicorp key vault dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: hashicorp-key-vault-dist
+#        path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+#    - name: Download kalium encryptor dist
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: kalium-dist
+#        path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+#    - name: Execute gradle integration tests
+#      run: |
+#        ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --fail-fast -PexcludeTests="RunHashicorpIT,AwsKeyVaultIT,RecoverIT,RunAzureIT,RestSuiteHttpH2RemoteEnclaveEncTypeEC,CucumberTestSuite" --info
+#    - name: Upload Junit reports
+#      uses: actions/upload-artifact@v2
+#      if: always()
+#      with:
+#       name: itest-junit-report
+#       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+#    - name: Upload test logs
+#      uses: actions/upload-artifact@v2
+#      if: always()
+#      with:
+#       name: itest-logs
+#       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#
+#  remote_enclave_itest:
+#    name: Remote enclave integration tests
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code from SCM
+#        uses: actions/checkout@v2
+#      - name: Set up Java
+#        uses: actions/setup-java@v2
+#        with:
+#          distribution: 'adopt'
+#          java-version: 14
+#          check-latest: true
+#      - name: Download tessera dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: tessera-dists
+#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+#      - name: Download tessera enclave dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: enclave-dists
+#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+#      - name: Download aws key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: aws-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+#      - name: Download azure key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: azure-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+#      - name: Download hashicorp key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: hashicorp-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+#      - name: Download kalium encryptor dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: kalium-dist
+#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+#      - name: Execute gradle integration tests
 #        run: |
-#          ./gradlew :tests:acceptance-test:test --tests RunAzureIT --info
-      - name: Run hashicorp tests
-        run: |
-          wget https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip -O /tmp/vault_1.2.2_linux_amd64.zip
-          mkdir -p vault/bin && pushd $_
-          unzip /tmp/vault_1.2.2_linux_amd64.zip
-          export PATH=$PATH:$PWD && popd
-          ./gradlew :tests:acceptance-test:test --tests RunHashicorpIT --info
-      - name: Upload junit reports
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: vault-itest-junit-report
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: vault-itest-logs
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-
-  recovery_itest:
-    name: Recovery integration tests
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code from SCM
-        uses: actions/checkout@v2
-      - name: Set up java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 14
-          check-latest: true
-      - name: Download tessera dist
-        uses: actions/download-artifact@v2
-        with:
-          name: tessera-dists
-          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-      - name: Download tessera enclave dist
-        uses: actions/download-artifact@v2
-        with:
-          name: enclave-dists
-          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-      - name: Download aws key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: aws-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-      - name: Download azure key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: azure-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-      - name: Download hashicorp key vault dist
-        uses: actions/download-artifact@v2
-        with:
-          name: hashicorp-key-vault-dist
-          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-      - name: Download kalium encryptor dist
-        uses: actions/download-artifact@v2
-        with:
-          name: kalium-dist
-          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-      - name: Execute tests
-        run: |
-          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests RecoverIT --info
-      - name: Upload junit reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: recovery_itest-junit-report
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: recovery-itest-logs
-          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#          ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC --info
+#      - name: Upload junit reports
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: remote_enclave_itest-junit-report
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+#      - name: Upload test logs
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: remote_enclave_itest-logs
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#
+#  cucumber_itest:
+#    name: Cucumber itests
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code from SCM
+#        uses: actions/checkout@v2
+#      - name: Set up Java
+#        uses: actions/setup-java@v2
+#        with:
+#          distribution: 'adopt'
+#          java-version: 14
+#          check-latest: true
+#      - name: Download tessera dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: tessera-dists
+#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+#      - name: Download tessera enclave dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: enclave-dists
+#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+#      - name: Download aws key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: aws-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+#      - name: Download azure key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: azure-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+#      - name: Download hashicorp key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: hashicorp-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+#      - name: Download kalium encryptor dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: kalium-dist
+#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+#      - name: Execute gradle
+#        run: |
+#          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests CucumberTestSuite --info
+#      - name: Upload junit reports
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: cucumber_itest-junit-report
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+#      - name: Upload test logs
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: cucumber_itest-logs
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#
+#  vaultTests:
+#    name: Key vault integration tests
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code from SCM
+#        uses: actions/checkout@v2
+#      - uses: actions/setup-java@v2
+#        with:
+#          distribution: 'adopt'
+#          java-version: 14
+#          check-latest: true
+#      - name: Download tessera dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: tessera-dists
+#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+#      - name: Download tessera enclave dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: enclave-dists
+#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+#      - name: Download aws key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: aws-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+#      - name: Download azure key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: azure-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+#      - name: Download hashicorp key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: hashicorp-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+#      - name: Download kalium encryptor dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: kalium-dist
+#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+#      - name: Run AWS tests
+#        run: |
+#          ./gradlew :tests:acceptance-test:test --tests AwsKeyVaultIT --info
+##      - name: Run azure tests
+##        run: |
+##          ./gradlew :tests:acceptance-test:test --tests RunAzureIT --info
+#      - name: Run hashicorp tests
+#        run: |
+#          wget https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip -O /tmp/vault_1.2.2_linux_amd64.zip
+#          mkdir -p vault/bin && pushd $_
+#          unzip /tmp/vault_1.2.2_linux_amd64.zip
+#          export PATH=$PATH:$PWD && popd
+#          ./gradlew :tests:acceptance-test:test --tests RunHashicorpIT --info
+#      - name: Upload junit reports
+#        uses: actions/upload-artifact@v2
+#        if: failure()
+#        with:
+#          name: vault-itest-junit-report
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+#      - name: Upload test logs
+#        uses: actions/upload-artifact@v2
+#        if: failure()
+#        with:
+#          name: vault-itest-logs
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#
+#  recovery_itest:
+#    name: Recovery integration tests
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code from SCM
+#        uses: actions/checkout@v2
+#      - name: Set up java
+#        uses: actions/setup-java@v2
+#        with:
+#          distribution: 'adopt'
+#          java-version: 14
+#          check-latest: true
+#      - name: Download tessera dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: tessera-dists
+#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+#      - name: Download tessera enclave dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: enclave-dists
+#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+#      - name: Download aws key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: aws-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+#      - name: Download azure key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: azure-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+#      - name: Download hashicorp key vault dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: hashicorp-key-vault-dist
+#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+#      - name: Download kalium encryptor dist
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: kalium-dist
+#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+#      - name: Execute tests
+#        run: |
+#          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests RecoverIT --info
+#      - name: Upload junit reports
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: recovery_itest-junit-report
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+#      - name: Upload test logs
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: recovery-itest-logs
+#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
 
   build_image:
     name: Build develop Docker image

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -410,8 +410,6 @@ jobs:
       - name: Get current date-time (RFC 3339 standard)
         id: date
         run: echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      - name: check env
-        run: env
       - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:
@@ -469,7 +467,7 @@ jobs:
           echo ::set-output name=version::$QUORUM_MINOR_VERSION
       - name: Execute acceptance tests
         run:
-          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_tessera_docker_image='{name="${TESSERA_DOCKER_IMAGE}:develop",local=true}' -e TF_VAR_quorum_docker_image='{name="${QUORUM_DOCKER_IMAGE}:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
+          docker run --entrypoint /bin/sh --network host -v /tmp/run/sh:/tmp/run.sh -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests -e TF_VAR_tessera_docker_image='{name="${{ env.TESSERA_DOCKER_IMAGE }}:develop",local=true}' -e TF_VAR_quorum_docker_image='{name="${{ env.QUORUM_DOCKER_IMAGE }}:${{ steps.quorumver.outputs.version }}",local=false}' quorumengineering/acctests:latest -c "./mvnw --no-transfer-progress -B -DskipToolsCheck test -Pauto -Dtags='\!async && (basic || basic-istanbul || networks/typical::istanbul)' -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true && cp -R /workspace/target/gauge /tmp/acctests/gauge && chmod -R 775 /tmp/acctests/gauge"
       - name: Upload Gauge report
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -446,24 +446,6 @@ jobs:
 #          job_name: Recovery integration tests
 #          url: ${{ secrets.SLACK_WEBHOOK }}
 
-#  get_docker_repo:
-#    name: Get the Docker repo name
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    outputs:
-#      docker-repo: ${{ steps.get.outputs.docker-repo }}
-#    steps:
-#      - name: Use secret or default
-#        id: get
-#        env:
-#          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
-#        run: |
-#          # use a non-existant repo as a default value - allows us to build images for tests but protect against PRs
-#          # from forks (that don't have access to secrets) pushing to the official repo
-#          val="${DOCKER_REPO:-quorumtest}"
-#          echo $val
-#          echo "::set-output name=docker-repo::$val"
-
   build_image:
     name: Build develop Docker image
     needs: [build]
@@ -477,7 +459,6 @@ jobs:
           # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
           # from forks (that don't have access to secrets) pushing to the official repo 
           val="${DOCKER_REPO:-quorumtest}"
-          echo $val
           echo "::set-output name=docker-repo::$val"
       - name: Checkout code from SCM
         uses: actions/checkout@v2
@@ -580,7 +561,6 @@ jobs:
           # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
           # from forks (that don't have access to secrets) pushing to the official repo 
           val="${DOCKER_REPO:-quorumtest}"
-          echo $val
           echo "::set-output name=docker-repo::$val"
       - name: Download image artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -446,11 +446,39 @@ jobs:
 #          job_name: Recovery integration tests
 #          url: ${{ secrets.SLACK_WEBHOOK }}
 
+#  get_docker_repo:
+#    name: Get the Docker repo name
+#    needs: [build]
+#    runs-on: ubuntu-latest
+#    outputs:
+#      docker-repo: ${{ steps.get.outputs.docker-repo }}
+#    steps:
+#      - name: Use secret or default
+#        id: get
+#        env:
+#          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+#        run: |
+#          # use a non-existant repo as a default value - allows us to build images for tests but protect against PRs
+#          # from forks (that don't have access to secrets) pushing to the official repo
+#          val="${DOCKER_REPO:-quorumtest}"
+#          echo $val
+#          echo "::set-output name=docker-repo::$val"
+
   build_image:
     name: Build develop Docker image
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - name: Use secret or default
+        id: get_docker_repo
+        env:
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
+          # from forks (that don't have access to secrets) pushing to the official repo 
+          val="${DOCKER_REPO:-quorumtest}"
+          echo $val
+          echo "::set-output name=docker-repo::$val"
       - name: Checkout code from SCM
         uses: actions/checkout@v2
       - name: Download tessera dist
@@ -466,7 +494,7 @@ jobs:
       - name: Build image as portable tar
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ secrets.DOCKER_REPO }}:develop
+          tags: ${{ steps.get_docker_repo.outputs.docker-repo }}:develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -544,6 +572,16 @@ jobs:
     needs: [build_image, atest]
     runs-on: ubuntu-latest
     steps:
+      - name: Use secret or default
+        id: get_docker_repo
+        env:
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
+          # from forks (that don't have access to secrets) pushing to the official repo 
+          val="${DOCKER_REPO:-quorumtest}"
+          echo $val
+          echo "::set-output name=docker-repo::$val"
       - name: Download image artifact
         uses: actions/download-artifact@v2
         with:
@@ -562,4 +600,4 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Push image
         run : |
-          docker push ${{ secrets.DOCKER_REPO }}:develop
+          docker push ${{ steps.get_docker_repo.outputs.docker-repo }}:develop

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -415,7 +415,7 @@ jobs:
       - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:
-          tags: ${TESSERA_DOCKER_IMAGE}:develop
+          tags: ${{ env.TESSERA_DOCKER_IMAGE }}:develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -410,6 +410,8 @@ jobs:
       - name: Get current date-time (RFC 3339 standard)
         id: date
         run: echo "::set-output name=now::$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      - name: check env
+        run: env
       - name: Build Docker image as portable tar
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,324 +74,324 @@ jobs:
     - name: Execute gradle dependencyCheckAnalyze task
       run: ./gradlew dependencyCheckAnalyze -x test
 
-#  test:
-#    name: Unit tests
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout code from SCM
-#      uses: actions/checkout@v2
-#    - name: Set up Java
-#      uses: actions/setup-java@v2
-#      with:
-#        distribution: 'adopt'
-#        java-version: 14
-#        check-latest: true
-#    - name: Execute gradle test
-#      run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
-#
-#  itest:
-#    name: Integration tests
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout code from SCM
-#      uses: actions/checkout@v2
-#    - name: Set up Java
-#      uses: actions/setup-java@v2
-#      with:
-#        distribution: 'adopt'
-#        java-version: 14
-#        check-latest: true
-#    - name: Download tessera dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: tessera-dists
-#        path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-#    - name: Download tessera enclave dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: enclave-dists
-#        path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-#    - name: Download aws key vault dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: aws-key-vault-dist
-#        path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-#    - name: Download azure key vault dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: azure-key-vault-dist
-#        path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-#    - name: Download hashicorp key vault dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: hashicorp-key-vault-dist
-#        path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-#    - name: Download kalium encryptor dist
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: kalium-dist
-#        path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#    - name: Execute gradle integration tests
-#      run: |
-#        ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --fail-fast -PexcludeTests="RunHashicorpIT,AwsKeyVaultIT,RecoverIT,RunAzureIT,RestSuiteHttpH2RemoteEnclaveEncTypeEC,CucumberTestSuite" --info
-#    - name: Upload Junit reports
-#      uses: actions/upload-artifact@v2
-#      if: always()
-#      with:
-#       name: itest-junit-report
-#       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-#    - name: Upload test logs
-#      uses: actions/upload-artifact@v2
-#      if: always()
-#      with:
-#       name: itest-logs
-#       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#
-#  remote_enclave_itest:
-#    name: Remote enclave integration tests
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code from SCM
-#        uses: actions/checkout@v2
-#      - name: Set up Java
-#        uses: actions/setup-java@v2
-#        with:
-#          distribution: 'adopt'
-#          java-version: 14
-#          check-latest: true
-#      - name: Download tessera dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: tessera-dists
-#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-#      - name: Download tessera enclave dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: enclave-dists
-#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-#      - name: Download aws key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: aws-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-#      - name: Download azure key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: azure-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-#      - name: Download hashicorp key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: hashicorp-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-#      - name: Download kalium encryptor dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: kalium-dist
-#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#      - name: Execute gradle integration tests
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code from SCM
+      uses: actions/checkout@v2
+    - name: Set up Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 14
+        check-latest: true
+    - name: Execute gradle test
+      run: ./gradlew test -x dependencyCheckAnalyze -x :tests:acceptance-test:test -x javadoc --info
+
+  itest:
+    name: Integration tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code from SCM
+      uses: actions/checkout@v2
+    - name: Set up Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 14
+        check-latest: true
+    - name: Download tessera dist
+      uses: actions/download-artifact@v2
+      with:
+        name: tessera-dists
+        path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+    - name: Download tessera enclave dist
+      uses: actions/download-artifact@v2
+      with:
+        name: enclave-dists
+        path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+    - name: Download aws key vault dist
+      uses: actions/download-artifact@v2
+      with:
+        name: aws-key-vault-dist
+        path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+    - name: Download azure key vault dist
+      uses: actions/download-artifact@v2
+      with:
+        name: azure-key-vault-dist
+        path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+    - name: Download hashicorp key vault dist
+      uses: actions/download-artifact@v2
+      with:
+        name: hashicorp-key-vault-dist
+        path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+    - name: Download kalium encryptor dist
+      uses: actions/download-artifact@v2
+      with:
+        name: kalium-dist
+        path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+    - name: Execute gradle integration tests
+      run: |
+        ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --fail-fast -PexcludeTests="RunHashicorpIT,AwsKeyVaultIT,RecoverIT,RunAzureIT,RestSuiteHttpH2RemoteEnclaveEncTypeEC,CucumberTestSuite" --info
+    - name: Upload Junit reports
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+       name: itest-junit-report
+       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+       name: itest-logs
+       path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+
+  remote_enclave_itest:
+    name: Remote enclave integration tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from SCM
+        uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 14
+          check-latest: true
+      - name: Download tessera dist
+        uses: actions/download-artifact@v2
+        with:
+          name: tessera-dists
+          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+      - name: Download tessera enclave dist
+        uses: actions/download-artifact@v2
+        with:
+          name: enclave-dists
+          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+      - name: Download aws key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: aws-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+      - name: Download azure key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: azure-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+      - name: Download hashicorp key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: hashicorp-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+      - name: Download kalium encryptor dist
+        uses: actions/download-artifact@v2
+        with:
+          name: kalium-dist
+          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+      - name: Execute gradle integration tests
+        run: |
+          ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC --info
+      - name: Upload junit reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: remote_enclave_itest-junit-report
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: remote_enclave_itest-logs
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+
+  cucumber_itest:
+    name: Cucumber itests
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from SCM
+        uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 14
+          check-latest: true
+      - name: Download tessera dist
+        uses: actions/download-artifact@v2
+        with:
+          name: tessera-dists
+          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+      - name: Download tessera enclave dist
+        uses: actions/download-artifact@v2
+        with:
+          name: enclave-dists
+          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+      - name: Download aws key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: aws-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+      - name: Download azure key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: azure-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+      - name: Download hashicorp key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: hashicorp-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+      - name: Download kalium encryptor dist
+        uses: actions/download-artifact@v2
+        with:
+          name: kalium-dist
+          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+      - name: Execute gradle
+        run: |
+          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests CucumberTestSuite --info
+      - name: Upload junit reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cucumber_itest-junit-report
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cucumber_itest-logs
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+
+  vaultTests:
+    name: Key vault integration tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from SCM
+        uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 14
+          check-latest: true
+      - name: Download tessera dist
+        uses: actions/download-artifact@v2
+        with:
+          name: tessera-dists
+          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+      - name: Download tessera enclave dist
+        uses: actions/download-artifact@v2
+        with:
+          name: enclave-dists
+          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+      - name: Download aws key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: aws-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+      - name: Download azure key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: azure-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+      - name: Download hashicorp key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: hashicorp-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+      - name: Download kalium encryptor dist
+        uses: actions/download-artifact@v2
+        with:
+          name: kalium-dist
+          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+      - name: Run AWS tests
+        run: |
+          ./gradlew :tests:acceptance-test:test --tests AwsKeyVaultIT --info
+#      - name: Run azure tests
 #        run: |
-#          ./gradlew :tests:acceptance-test:test --tests RestSuiteHttpH2RemoteEnclave --tests RestSuiteHttpH2RemoteEnclaveEncTypeEC --info
-#      - name: Upload junit reports
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: remote_enclave_itest-junit-report
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-#      - name: Upload test logs
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: remote_enclave_itest-logs
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#
-#  cucumber_itest:
-#    name: Cucumber itests
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code from SCM
-#        uses: actions/checkout@v2
-#      - name: Set up Java
-#        uses: actions/setup-java@v2
-#        with:
-#          distribution: 'adopt'
-#          java-version: 14
-#          check-latest: true
-#      - name: Download tessera dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: tessera-dists
-#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-#      - name: Download tessera enclave dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: enclave-dists
-#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-#      - name: Download aws key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: aws-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-#      - name: Download azure key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: azure-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-#      - name: Download hashicorp key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: hashicorp-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-#      - name: Download kalium encryptor dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: kalium-dist
-#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#      - name: Execute gradle
-#        run: |
-#          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests CucumberTestSuite --info
-#      - name: Upload junit reports
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: cucumber_itest-junit-report
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-#      - name: Upload test logs
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: cucumber_itest-logs
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#
-#  vaultTests:
-#    name: Key vault integration tests
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code from SCM
-#        uses: actions/checkout@v2
-#      - uses: actions/setup-java@v2
-#        with:
-#          distribution: 'adopt'
-#          java-version: 14
-#          check-latest: true
-#      - name: Download tessera dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: tessera-dists
-#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-#      - name: Download tessera enclave dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: enclave-dists
-#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-#      - name: Download aws key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: aws-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-#      - name: Download azure key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: azure-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-#      - name: Download hashicorp key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: hashicorp-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-#      - name: Download kalium encryptor dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: kalium-dist
-#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#      - name: Run AWS tests
-#        run: |
-#          ./gradlew :tests:acceptance-test:test --tests AwsKeyVaultIT --info
-##      - name: Run azure tests
-##        run: |
-##          ./gradlew :tests:acceptance-test:test --tests RunAzureIT --info
-#      - name: Run hashicorp tests
-#        run: |
-#          wget https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip -O /tmp/vault_1.2.2_linux_amd64.zip
-#          mkdir -p vault/bin && pushd $_
-#          unzip /tmp/vault_1.2.2_linux_amd64.zip
-#          export PATH=$PATH:$PWD && popd
-#          ./gradlew :tests:acceptance-test:test --tests RunHashicorpIT --info
-#      - name: Upload junit reports
-#        uses: actions/upload-artifact@v2
-#        if: failure()
-#        with:
-#          name: vault-itest-junit-report
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-#      - name: Upload test logs
-#        uses: actions/upload-artifact@v2
-#        if: failure()
-#        with:
-#          name: vault-itest-logs
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
-#
-#  recovery_itest:
-#    name: Recovery integration tests
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code from SCM
-#        uses: actions/checkout@v2
-#      - name: Set up java
-#        uses: actions/setup-java@v2
-#        with:
-#          distribution: 'adopt'
-#          java-version: 14
-#          check-latest: true
-#      - name: Download tessera dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: tessera-dists
-#          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
-#      - name: Download tessera enclave dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: enclave-dists
-#          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
-#      - name: Download aws key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: aws-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
-#      - name: Download azure key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: azure-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
-#      - name: Download hashicorp key vault dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: hashicorp-key-vault-dist
-#          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
-#      - name: Download kalium encryptor dist
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: kalium-dist
-#          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
-#      - name: Execute tests
-#        run: |
-#          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests RecoverIT --info
-#      - name: Upload junit reports
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: recovery_itest-junit-report
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
-#      - name: Upload test logs
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: recovery-itest-logs
-#          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+#          ./gradlew :tests:acceptance-test:test --tests RunAzureIT --info
+      - name: Run hashicorp tests
+        run: |
+          wget https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip -O /tmp/vault_1.2.2_linux_amd64.zip
+          mkdir -p vault/bin && pushd $_
+          unzip /tmp/vault_1.2.2_linux_amd64.zip
+          export PATH=$PATH:$PWD && popd
+          ./gradlew :tests:acceptance-test:test --tests RunHashicorpIT --info
+      - name: Upload junit reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: vault-itest-junit-report
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: vault-itest-logs
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
+
+  recovery_itest:
+    name: Recovery integration tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from SCM
+        uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 14
+          check-latest: true
+      - name: Download tessera dist
+        uses: actions/download-artifact@v2
+        with:
+          name: tessera-dists
+          path: /home/runner/work/tessera/tessera/tessera-dist/build/distributions/
+      - name: Download tessera enclave dist
+        uses: actions/download-artifact@v2
+        with:
+          name: enclave-dists
+          path: /home/runner/work/tessera/tessera/enclave/enclave-jaxrs/build/distributions/
+      - name: Download aws key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: aws-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/aws-key-vault/build/distributions/
+      - name: Download azure key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: azure-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/azure-key-vault/build/distributions/
+      - name: Download hashicorp key vault dist
+        uses: actions/download-artifact@v2
+        with:
+          name: hashicorp-key-vault-dist
+          path: /home/runner/work/tessera/tessera/key-vault/hashicorp-key-vault/build/distributions/
+      - name: Download kalium encryptor dist
+        uses: actions/download-artifact@v2
+        with:
+          name: kalium-dist
+          path: /home/runner/work/tessera/tessera/encryption/encryption-kalium/build/distributions/
+      - name: Execute tests
+        run: |
+          ./gradlew :tests:acceptance-test:clean :tests:acceptance-test:test --tests RecoverIT --info
+      - name: Upload junit reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: recovery_itest-junit-report
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/reports/tests/
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: recovery-itest-logs
+          path: /home/runner/work/tessera/tessera/tests/acceptance-test/build/logs
 
   build_image:
     name: Build develop Docker image

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -458,8 +458,8 @@ jobs:
         run: |
           # use a non-existent repo as a default value - allows us to build images for tests but protect against PRs 
           # from forks (that don't have access to secrets) pushing to the official repo 
-          val="${DOCKER_REPO:-quorumtest}"
-          echo "::set-output name=docker-repo::$val"
+#          val="${DOCKER_REPO:-quorumtest}"
+          echo "::set-output name=docker-repo::${DOCKER_REPO:-quorumtest}"
       - name: Checkout code from SCM
         uses: actions/checkout@v2
       - name: Download tessera dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ env:
   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   GPG_EXECUTABLE: ${{ secrets.GPG_EXECUTABLE }}
   GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+  TESSERA_DOCKER_IMAGE: quorumengineering/tessera
 
 jobs:
   checkdependencies:
@@ -133,9 +134,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:latest
-            ${{ secrets.DOCKER_REPO }}:${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:${{ needs.release_sonatype.outputs.full-ver }}
+            ${TESSERA_DOCKER_IMAGE}:latest
+            ${TESSERA_DOCKER_IMAGE}:${{ needs.release_sonatype.outputs.minor-ver }}
+            ${TESSERA_DOCKER_IMAGE}:${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -148,9 +149,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:azure-latest
-            ${{ secrets.DOCKER_REPO }}:azure-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:azure-${{ needs.release_sonatype.outputs.full-ver }}
+            ${TESSERA_DOCKER_IMAGE}:azure-latest
+            ${TESSERA_DOCKER_IMAGE}:azure-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${TESSERA_DOCKER_IMAGE}:azure-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -163,9 +164,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:aws-latest
-            ${{ secrets.DOCKER_REPO }}:aws-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:aws-${{ needs.release_sonatype.outputs.full-ver }}
+            ${TESSERA_DOCKER_IMAGE}:aws-latest
+            ${TESSERA_DOCKER_IMAGE}:aws-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${TESSERA_DOCKER_IMAGE}:aws-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -178,9 +179,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKER_REPO }}:hashicorp-latest
-            ${{ secrets.DOCKER_REPO }}:hashicorp-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${{ secrets.DOCKER_REPO }}:hashicorp-${{ needs.release_sonatype.outputs.full-ver }}
+            ${TESSERA_DOCKER_IMAGE}:hashicorp-latest
+            ${TESSERA_DOCKER_IMAGE}:hashicorp-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${TESSERA_DOCKER_IMAGE}:hashicorp-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${TESSERA_DOCKER_IMAGE}:latest
-            ${TESSERA_DOCKER_IMAGE}:${{ needs.release_sonatype.outputs.minor-ver }}
-            ${TESSERA_DOCKER_IMAGE}:${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:latest
+            ${{ env.TESSERA_DOCKER_IMAGE }}:${{ needs.release_sonatype.outputs.minor-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -149,9 +149,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${TESSERA_DOCKER_IMAGE}:azure-latest
-            ${TESSERA_DOCKER_IMAGE}:azure-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${TESSERA_DOCKER_IMAGE}:azure-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:azure-latest
+            ${{ env.TESSERA_DOCKER_IMAGE }}:azure-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:azure-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -164,9 +164,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${TESSERA_DOCKER_IMAGE}:aws-latest
-            ${TESSERA_DOCKER_IMAGE}:aws-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${TESSERA_DOCKER_IMAGE}:aws-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:aws-latest
+            ${{ env.TESSERA_DOCKER_IMAGE }}:aws-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:aws-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -179,9 +179,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${TESSERA_DOCKER_IMAGE}:hashicorp-latest
-            ${TESSERA_DOCKER_IMAGE}:hashicorp-${{ needs.release_sonatype.outputs.minor-ver }}
-            ${TESSERA_DOCKER_IMAGE}:hashicorp-${{ needs.release_sonatype.outputs.full-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:hashicorp-latest
+            ${{ env.TESSERA_DOCKER_IMAGE }}:hashicorp-${{ needs.release_sonatype.outputs.minor-ver }}
+            ${{ env.TESSERA_DOCKER_IMAGE }}:hashicorp-${{ needs.release_sonatype.outputs.full-ver }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Tessera Release Build
 
 on:
-  repository_dispatch:
-    types: [release]
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Target release version (will be checked against branch version to protect against accidentally releasing wrong artifacts)'
+        required: true
+        type: string
 
 env:
   SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -33,18 +37,31 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Get release version
+        id: version
+        run: echo "::set-output name=tag::$(cat version.txt | cut -d '-' -f 1)"
+      - name: Check release version
+        env:
+          USER_VERSION: ${{ github.event.inputs.release-version }}
+          TAG_VERSION: ${{ steps.version.outputs.tag }}
+        run: |
+          if [ ! $USER_VERSION -eq $TAG_VERSION ]; then
+            echo "user-provided version (${{ github.event.inputs.release-version }} does not match tag version (${{ steps.version.outputs.tag }}) derived from version.txt, exiting)"
+            exit 1
+          fi
       - name: Release
         id: release
+        env:
+          tag-version: ${{ steps.version.outputs.tag }}
         run: |
           git config user.name "quorumbot"
           now=`date +%Y%m%d%H%M%S`
-          tagversion=`cat version.txt | cut -d'-' -f1`
-          tagname="tessera-$tagversion"
+          tagname="tessera-$TAG_VERSION
           echo "Releasing $tagname"
-          echo "$tagversion" > version.txt
+          echo "$TAG_VERSION" > version.txt
           git add version.txt
-          git commit -m "Change to release version $tagversion"
-          git tag -a $tagname -m "Release tessera $tagversion"
+          git commit -m "Change to release version $TAG_VERSION"
+          git tag -a $TAG_VERSION -m "Release tessera $TAG_VERSION"
           git push --tags
 
           echo "${GPG_SECRET_KEYS}" | base64 --decode | gpg --import --no-tty --batch --yes
@@ -55,8 +72,8 @@ jobs:
           git add version.txt
           git commit -m "Change version to next development version"
 
-          minor_version=${tagversion%.*}
-          echo ::set-output name=full-ver::$tagversion
+          minor_version=${$TAG_VERSION%.*}
+          echo ::set-output name=full-ver::$TAG_VERSION
           echo ::set-output name=minor-ver::$minor_version
           echo ::set-output name=branch-name::release-$now
       - name: Create PR to update development version


### PR DESCRIPTION
Fork PRs do not have access to the docker repo stored as a secret.  This was causing the docker image build step to fail meaning atests were not being run.  If secrets are not available, use an arbitrary default so the image can still be built and the tests run.  PRs do not push any images so it is fine to use an arbitrary value.